### PR TITLE
add support for byte arrays

### DIFF
--- a/src/main/java/com/linkedin/camus/etl/kafka/coders/ByteArrayMessageDecoder.java
+++ b/src/main/java/com/linkedin/camus/etl/kafka/coders/ByteArrayMessageDecoder.java
@@ -1,0 +1,19 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import java.util.Properties;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.MessageDecoder;
+
+public class ByteArrayMessageDecoder extends MessageDecoder<byte[], byte[]> {
+    @Override
+    public void init(Properties props, String topicName) {
+        this.props = props;
+        this.topicName = topicName;
+    }
+
+    @Override
+    public CamusWrapper<byte[]> decode(byte[] payload) {
+        return new CamusWrapper<byte[]>(payload, System.currentTimeMillis());
+    }
+}

--- a/src/main/java/com/linkedin/camus/etl/kafka/common/ByteArrayRecordWriterProvider.java
+++ b/src/main/java/com/linkedin/camus/etl/kafka/common/ByteArrayRecordWriterProvider.java
@@ -1,0 +1,61 @@
+package com.linkedin.camus.etl.kafka.common;
+
+import java.io.IOException;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+
+public class ByteArrayRecordWriterProvider implements RecordWriterProvider {
+    public final static String EXT = ".gz";
+
+    public ByteArrayRecordWriterProvider(TaskAttemptContext context) {
+    }
+
+    @Override
+    public String getFilenameExtension() {
+        return EXT;
+    }
+
+    @Override
+    public RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(
+            TaskAttemptContext context,
+            String fileName,
+            CamusWrapper data,
+            FileOutputCommitter committer) throws IOException, InterruptedException {
+        Configuration conf = context.getConfiguration();
+        FileSystem fs = FileSystem.get(conf);
+
+        Path path = committer.getWorkPath();
+        path = new Path(path, EtlMultiOutputFormat.getUniqueFile(context, fileName, EXT));
+
+        CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
+        CompressionCodec codec = codecFactory.getCodec(path);
+
+        final CompressionOutputStream writer = codec.createOutputStream(fs.create(path));
+
+        return new RecordWriter<IEtlKey, CamusWrapper>() {
+            @Override
+            public void write(IEtlKey ignore, CamusWrapper data) throws IOException {
+                byte[] record = (byte[]) data.getRecord();
+                writer.write(record);
+            }
+
+            @Override
+            public void close(TaskAttemptContext arg0) throws IOException, InterruptedException {
+                writer.close();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Even though we can pass a magic byte at the start of a message value to skip JSON parsing, the current writer doesn't support a byte array. It's also better to have an explicit decoder/writer configuration rather than infer it from the message value.